### PR TITLE
READY.FOR.RELEASE 0.1.0-pre-alpha

### DIFF
--- a/n.READY.FOR.RELEASE
+++ b/n.READY.FOR.RELEASE
@@ -1,0 +1,11 @@
+0.1.0-pre-alpha READY.FOR.RELEASE
+
+last commit 5a176f584cd38ac1ae9400bf7aebed77335ae988
+
+Date:   Tue Jul 11 17:40:59 UTC 2023
+
+    KLUDGE - clean up print channel program start
+    
+      Just sent the USB to USART bridge a few spaced println's,
+      to train the autobaud or whatever it is doing to print.
+      Saw too much junk on the terminal otherwise.


### PR DESCRIPTION
Lock in basic serial printing which now works

	new file:   n.READY.FOR.RELEASE

On branch release/0.1.0-pre-alpha